### PR TITLE
Update game screenshots to represent the current version of the game

### DIFF
--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -23,19 +23,19 @@
       <caption>Title screen</caption>
     </screenshot>
     <screenshot>
-      <image>https://www.srb2.org/wp-content/uploads/21-gfz2.png</image>
+      <image>https://www.srb2.org/wp-content/uploads/GFZ2.png</image>
       <caption>Singleplayer (Sonic)</caption>
     </screenshot>
     <screenshot>
-      <image>https://www.srb2.org/wp-content/uploads/21-dsz2.png</image>
+      <image>https://www.srb2.org/wp-content/uploads/srb21244.png</image>
       <caption>Singleplayer (Tails)</caption>
     </screenshot>
     <screenshot>
-      <image>https://www.srb2.org/wp-content/uploads/21-thz2.png</image>
+      <image>https://www.srb2.org/wp-content/uploads/rvz1knux.png</image>
       <caption>Singleplayer (Knuckles)</caption>
     </screenshot>
     <screenshot>
-      <image>https://www.srb2.org/media_data/coop1.png</image>
+      <image>https://www.srb2.org/wp-content/uploads/srb20057.png</image>
       <caption>Multiplayer</caption>
     </screenshot>
   </screenshots>


### PR DESCRIPTION
The screenshots currently being used are from an earlier version of the game (2.0.x or 2.1.x, I'm not sure) and do not reflect the current state of the game, which is much more beautiful and well crafted.

I replaced the screenshots with more recent ones, from version 2.2.x, available on the official Sonic Robo Blast 2 website at <https://www.srb2.org/media/>.