### PR TITLE
Update OARS metadata

### DIFF
--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -63,7 +63,7 @@
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">moderate</content_attribute>
     <content_attribute id="language-humor">mild</content_attribute>
-    <content_attribute id="social-chat">mild</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
     <content_attribute id="social-info">mild</content_attribute>
   </content_rating>
 </component>


### PR DESCRIPTION
Resolves #62 and should show a more fitting age rating on stuff that supports OARS ratings.
I believe ``intense`` is the right value for this situation, for uncontrolled chat functionality between users rather than ``moderate`` for moderated chat. STJr does have rules for servers listed on their server browser, but the servers listed are owned by players and aren't entirely controlled by STJr, and most community servers allow swearing in their text chats.