### PR TITLE
Re-enable native Wayland socket

### DIFF
--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -7,7 +7,8 @@ finish-args:
   - --share=ipc
   - --share=network
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --device=all
   - --persist=.srb2
 modules:


### PR DESCRIPTION
After testing, #59 does not seem to be an issue anymore. Even on GNOME Wayland, I was able to get working window decorations, fullscreen, and a normal window size. It should be fine to re-enable the wayland socket now. I also tested this on KDE Plasma Wayland and Hyprland. 
![Screenshot from 2025-01-14 14-57-26](https://github.com/user-attachments/assets/546445bc-5450-4584-92b2-b7ee4aca00db)
