### PR TITLE
Misc. build improvements

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -10,13 +10,15 @@ finish-args:
   - --socket=x11
   - --device=all
   - --persist=.srb2
+cleanup:
+  - /include
+  - /lib/*.la
+  - /lib/*.so
+  - /lib/pkgconfig
+  - /share/doc
 modules:
   - name: game-music-emu
     buildsystem: cmake-ninja
-    cleanup:
-      - /include
-      - /lib/*.so
-      - /lib/pkgconfig
     sources:
       - type: archive
         url: https://github.com/libgme/game-music-emu/archive/refs/tags/0.6.3.tar.gz
@@ -35,12 +37,6 @@ modules:
       - --disable-tests
       - --without-portaudio
       - --without-portaudiocpp
-    cleanup:
-      - /include
-      - /lib/*.la
-      - /lib/*.so
-      - /lib/pkgconfig
-      - /share/doc
     sources:
       - type: archive
         url: https://lib.openmpt.org/files/libopenmpt/src/libopenmpt-0.7.13+release.autotools.tar.gz
@@ -69,16 +65,8 @@ modules:
 
   - name: srb2
     buildsystem: simple
-    build-options:
-      arch:
-        aarch64:
-          env:
-            ARCH_MAKE_ARGS: LINUX64=1
-        x86_64:
-          env:
-            ARCH_MAKE_ARGS: LINUX64=1 X86_64=1
     build-commands:
-      - make -C src -j $FLATPAK_BUILDER_N_JOBS $ARCH_MAKE_ARGS
+      - make LINUX64=1 -j $FLATPAK_BUILDER_N_JOBS
       - install -D -m 755 -t $FLATPAK_DEST/bin bin/lsdl2srb2
       - install -D -m 644 srb2.png $FLATPAK_DEST/share/icons/hicolor/256x256/apps/$FLATPAK_ID.png
       - install -D -m 755 srb2.sh $FLATPAK_DEST/bin/srb2


### PR DESCRIPTION
- shared-modules is currently unused and can be removed
- cleanup can be done at the top level
- architecture specific build options aren't needed