### PR TITLE
Update to 2.2.15

### DIFF
--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -57,70 +57,56 @@
     <release version="2.2.15" date="2025-01-26" >
       <url type="details">https://git.do.srb2.org/STJr/SRB2/-/wikis/Changelogs/2.2.15</url>
       <description>
-       <h2>Bugfixes</h2>
-       <ul>
-        <li>Fixed regressions:
-         <ul>
-          <li>Caused by b20b71b (!2592)</li>
-          <li>Caused by !2211 (!2597)</li>
-          <li>Caused by !2227 (!2599)</li>
-          <li>Caused by !2100 (!2588)</li>
-          <li>Caused by !2587 (!2598)</li>
-          <li>Caused by !2425 (!2581)</li>
-          <li>Fixed in-game Master Server listing (!2603)</li>
-          <li>Fixed
-           <code>skin.sprites[i]</code> when used with 
-           <code>FF_SPR2SUPER</code> (!2613)
-          </li>
-          <li>Fixed character select regression (!2614)</li>
-         </ul>
-        </li>
-        <li>Fixed file downloader checking the old asset file names (!2596)</li>
-        <li>Fixed single player level select conditions (!2609, !2611)</li>
-        <li>Reapplied 
-         <code>invcolor</code> changes from !2116 (!2595)
-        </li>
-       </ul>
-       <h2>Optimizations</h2>
-       <ul>
-        <li>Inlined P_MobjWasRemoved (!2616)</li>
-       </ul>
-       <h2>Other</h2>
-       <ul>
-        <li>Made Fang/Amy/Metal Sonic objects use their respective skins</li>
-       </ul>
-       <h2>Resource files</h2>
-       <ul>
-        <li>
-         <code>srb2.pk3</code>
-         <ul>
-          <li>Removed duplicated sprites</li>
-         </ul>
-        </li>
-        <li>
-         <code>zones.pk3</code>
-         <ul>
-          <li>Fixed map issues</li>
-         </ul>
-        </li>
-        <li>
-         <code>characters.pk3</code>
-         <ul>
-          <li>Updated old sprites</li>
-          <li>Added 
-           <code>MSCx</code> sprites
-          </li>
-         </ul>
-        </li>
-        <li>
-         <code>music.pk3</code>
-         <ul>
-          <li>Updated 
-           <code>MUSICDEF</code>
-          </li>
-         </ul>
-        </li>
-       </ul>
+       Bugfixes
+
+        Fixed regressions:
+
+          Caused by b20b71b (!2592)
+          Caused by !2211 (!2597)
+          Caused by !2227 (!2599)
+          Caused by !2100 (!2588)
+          Caused by !2587 (!2598)
+          Caused by !2425 (!2581)
+          Fixed in-game Master Server listing (!2603)
+          Fixed
+           skin.sprites[i] when used with 
+           FF_SPR2SUPER (!2613)
+
+          Fixed character select regression (!2614)
+
+        Fixed file downloader checking the old asset file names (!2596)
+        Fixed single player level select conditions (!2609, !2611)
+        Reapplied 
+         invcolor changes from !2116 (!2595)
+
+       Optimizations
+
+        Inlined P_MobjWasRemoved (!2616)
+
+       Other
+
+        Made Fang/Amy/Metal Sonic objects use their respective skins
+
+       Resource files
+
+         srb2.pk3
+
+          Removed duplicated sprites
+
+         zones.pk3
+
+          Fixed map issues
+
+         characters.pk3
+
+          Updated old sprites
+          Added 
+           MSCx sprites
+
+         music.pk3
+
+          Updated 
+           MUSICDEF
       </description>
     </release>
     <release version="2.2.13" date="2023-09-09" >

--- a/org.srb2.SRB2.metainfo.xml
+++ b/org.srb2.SRB2.metainfo.xml
@@ -54,8 +54,74 @@
     <binary>srb2</binary>
   </provides>
   <releases>
-    <release version="2.2.14" date="2025-01-16" >
-      <url type="details">https://git.do.srb2.org/STJr/SRB2/-/wikis/Changelogs/2.2.14</url>
+    <release version="2.2.15" date="2025-01-26" >
+      <url type="details">https://git.do.srb2.org/STJr/SRB2/-/wikis/Changelogs/2.2.15</url>
+      <description>
+       <h2>Bugfixes</h2>
+       <ul>
+        <li>Fixed regressions:
+         <ul>
+          <li>Caused by b20b71b (!2592)</li>
+          <li>Caused by !2211 (!2597)</li>
+          <li>Caused by !2227 (!2599)</li>
+          <li>Caused by !2100 (!2588)</li>
+          <li>Caused by !2587 (!2598)</li>
+          <li>Caused by !2425 (!2581)</li>
+          <li>Fixed in-game Master Server listing (!2603)</li>
+          <li>Fixed
+           <code>skin.sprites[i]</code> when used with 
+           <code>FF_SPR2SUPER</code> (!2613)
+          </li>
+          <li>Fixed character select regression (!2614)</li>
+         </ul>
+        </li>
+        <li>Fixed file downloader checking the old asset file names (!2596)</li>
+        <li>Fixed single player level select conditions (!2609, !2611)</li>
+        <li>Reapplied 
+         <code>invcolor</code> changes from !2116 (!2595)
+        </li>
+       </ul>
+       <h2>Optimizations</h2>
+       <ul>
+        <li>Inlined P_MobjWasRemoved (!2616)</li>
+       </ul>
+       <h2>Other</h2>
+       <ul>
+        <li>Made Fang/Amy/Metal Sonic objects use their respective skins</li>
+       </ul>
+       <h2>Resource files</h2>
+       <ul>
+        <li>
+         <code>srb2.pk3</code>
+         <ul>
+          <li>Removed duplicated sprites</li>
+         </ul>
+        </li>
+        <li>
+         <code>zones.pk3</code>
+         <ul>
+          <li>Fixed map issues</li>
+         </ul>
+        </li>
+        <li>
+         <code>characters.pk3</code>
+         <ul>
+          <li>Updated old sprites</li>
+          <li>Added 
+           <code>MSCx</code> sprites
+          </li>
+         </ul>
+        </li>
+        <li>
+         <code>music.pk3</code>
+         <ul>
+          <li>Updated 
+           <code>MUSICDEF</code>
+          </li>
+         </ul>
+        </li>
+       </ul>
+      </description>
     </release>
     <release version="2.2.13" date="2023-09-09" >
       <url type="details">https://git.do.srb2.org/STJr/SRB2/-/wikis/Changelogs/2.2.13</url>

--- a/org.srb2.SRB2.yaml
+++ b/org.srb2.SRB2.yaml
@@ -87,8 +87,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/STJr/SRB2
-        tag: SRB2_release_2.2.14
-        commit: 7b6bf976646e44f6fa4ed92700770b64dfcdcfbc
+        tag: SRB2_release_2.2.15
+        commit: 8701ef41f617c06e23a7b8ccd2199c160c5d1dd1
       - type: script
         commands:
           - export SRB2WADDIR=/app/bin
@@ -106,5 +106,5 @@ modules:
     sources:
       - type: git
         url: https://git.do.srb2.org/STJr/srb2assets-public
-        tag: SRB2_release_2.2.14
-        commit: e160f328b9a4557f2ac7de8fa91ae028b0764950
+        tag: SRB2_release_2.2.15
+        commit: f9651218133f1001df39265bb53ac80ff19762a4


### PR DESCRIPTION
This is mainly a hotfix to address all of the issues that came with 2.2.14, so there’s not much to write home about, except that now you can play the game as intended again.

Additionally, we have chosen to revert Pipe Towers Zone to its previous version in order to resolve some asset crediting issues that sprang up after launch – for this and other reasons, 2.2.14 will no longer be available for download.